### PR TITLE
Could sec:java-sec-code:1.0.0 drop off redundant dependencies?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,24 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>23.0</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>j2objc-annotations</artifactId>
+                   <groupId>com.google.j2objc</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>error_prone_annotations</artifactId>
+                   <groupId>com.google.errorprone</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>animal-sniffer-annotations</artifactId>
+                   <groupId>org.codehaus.mojo</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>jsr305</artifactId>
+                   <groupId>com.google.code.findbugs</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -89,6 +107,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.12</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>commons-logging</artifactId>
+                   <groupId>commons-logging</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -141,6 +165,12 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
             <version>1.4.0.RELEASE</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>jsr305</artifactId>
+                   <groupId>com.google.code.findbugs</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- 生成uuid -->
@@ -215,12 +245,28 @@
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>3.9</version> <!-- 3.10-FINAL -->
+            <exclusions>
+                 <exclusion>
+                   <artifactId>xml-apis</artifactId>
+                   <groupId>xml-apis</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.monitorjbl</groupId>
             <artifactId>xlsx-streamer</artifactId>
             <version>2.0.0</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>xml-apis</artifactId>
+                   <groupId>xml-apis</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>icu4j</artifactId>
+                   <groupId>com.ibm.icu</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- ssrf -->
@@ -242,12 +288,28 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
             <version>4.1.4</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>commons-logging</artifactId>
+                   <groupId>commons-logging</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
             <version>2.9.2</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>mapstruct</artifactId>
+                   <groupId>org.mapstruct</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>byte-buddy</artifactId>
+                   <groupId>net.bytebuddy</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -285,6 +347,12 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>1.9.4</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>commons-logging</artifactId>
+                   <groupId>commons-logging</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt -->


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/126549527/233093438-83a9e144-310e-486c-b5f6-c76f1c77ae12.png)
![image](https://user-images.githubusercontent.com/126549527/233093561-bdab24fb-e70d-4137-91a1-c22a223c41c1.png)
![image](https://user-images.githubusercontent.com/126549527/233093655-ded819f4-7ed5-4306-ae61-d8c69c790a47.png)
![image](https://user-images.githubusercontent.com/126549527/233093760-32dbf4e2-8ec3-44ff-ac3b-3f4ae54b14de.png)
![image](https://user-images.githubusercontent.com/126549527/233093936-56e5f9eb-5d77-4483-ae2e-e30ac38ff7da.png)

Hi, I found that **_sec:java-sec-code:1.0.0_**’s pom file introduced **_199_** dependencies. However, among them, **_8_** libraries (**_4%_** have not been used by your project), the redundant dependencies are listed below.

More seriously, **_8_**  redundant libraries have not been maintained by developers for more than **_3_** years (outdated dependencies).


Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with outdated. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.

This PR **_sec:java-sec-code:1.0.0_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant indirect dependencies:
        net.bytebuddy:byte-buddy:1.8.12:compile [2 MB]
        com.google.errorprone:error_prone_annotations:2.0.18:compile [11 KB]
        xml-apis:xml-apis:1.4.01:compile [215 KB]
        com.google.j2objc:j2objc-annotations:1.1:compile [8 KB]
        org.codehaus.mojo:animal-sniffer-annotations:1.14:compile [3 KB]
        org.mapstruct:mapstruct:1.2.0.Final:compile [20 KB]
        com.ibm.icu:icu4j:4.6:compile [5 MB]
        com.google.code.findbugs:jsr305:1.3.9:compile [32 KB]

## Outdated dependencies
xml-apis:xml-apis:1.4.01 (**_4260_** days without maintenance)
org.codehaus.mojo:animal-sniffer-annotations:1.14 (**_2974_** days without maintenance)
com.google.errorprone:error_prone_annotations:2.0.18 (**_2240_** days without maintenance)
com.google.code.findbugs:jsr305:1.3.9 (**_4985_** days without maintenance)
net.bytebuddy:byte-buddy:1.8.12 (**_1789_** days without maintenance)
org.mapstruct:mapstruct:1.2.0.Final (**_2009_** days without maintenance)
com.ibm.icu:icu4j:4.6 (**_4520_** days without maintenance)
com.google.j2objc:j2objc-annotations:1.1 (**_2281_** days without maintenance)